### PR TITLE
Ensure embedded videos fill width and maintain aspect ratio

### DIFF
--- a/src/video/components/DefaultVideoComponent.js
+++ b/src/video/components/DefaultVideoComponent.js
@@ -15,15 +15,17 @@ const getSrc = ({ url, srcID, srcType }) => {
 const DefaultVideoCompoent = props => {
   const { blockProps } = props;
   const src = getSrc(blockProps);
+  const aspectRatio = 16/9;
+  const paddingTop = `${100/aspectRatio}%`;
 
   if (src) {
     return (
-      <iframe
-        style={{ width: '100%' }}
-        src={src}
-        frameBorder="0"
-        allowFullScreen
-      ></iframe>
+      <div style={{ position: 'relative' }}>
+        <div style={{ display: 'block', width: '100%', padding: `${paddingTop} 0 0 0`, margin: 0 }}></div>
+        <div style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, padding: 0, margin: 0 }}>
+          <iframe width='100%' height='100%' src={src} frameBorder='0' allowFullScreen></iframe>
+        </div>
+      </div>
     );
   }
 


### PR DESCRIPTION
This ensures that the out of the box experience for the plugin embeds videos that are the full width and the correct height. It involves using some standard CSS hacks to get an element with correct aspect ratio.